### PR TITLE
Add regression for nested have-by tactics

### DIFF
--- a/test/corpus/tactics.txt
+++ b/test/corpus/tactics.txt
@@ -155,3 +155,30 @@ example : True := by simp [*, foo]
           arg: (list_lit
             (star)
             (identifier)))))))
+
+==============
+Nested have-by tactic
+==============
+
+example : True := by
+  have h : True := by
+    exact trivial
+  exact h
+
+---
+
+(module
+  (declaration
+    (example
+      type: (true_const)
+      body: (by
+        stmt: (have
+          name: (identifier)
+          type: (true_const)
+          value: (by
+            stmt: (app
+              fn: (identifier)
+              arg: (identifier))))
+        stmt: (app
+          fn: (identifier)
+          arg: (identifier))))))


### PR DESCRIPTION
Adds a small corpus regression for #18.

The new case covers a valid Lean tactic block:

```lean
example : True := by
  have h : True := by
    exact trivial
  exact h
```

Current `main` parses the nested `by` as an `ERROR` node and consumes the following sibling tactic as the `have` value. The expected tree keeps the nested `by` as the `have` value and parses `exact h` as a sibling tactic statement.

Validation:

```text
pnpm exec tree-sitter test
```

This is intentionally a red regression test at the moment: all existing corpus cases pass, and the only failure is the new `Nested have-by tactic` case.